### PR TITLE
Removed env.js variables from default app.vue

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -4,7 +4,7 @@
       return {
         image: require('src/logo.png'),
         title: 'ue-Build',
-        message: 'Nice job! Youve made it!'
+        message: 'Nice job! You\'ve made it!'
       }
     },
     methods: {

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,14 +1,10 @@
 <script>
-  /* globals ENVIRONMENT,PORT */
-
   export default {
     data: function () {
       return {
         image: require('src/logo.png'),
         title: 'ue-Build',
-        message: 'Nice job! Youve made it!',
-        environment: ENVIRONMENT,
-        port: PORT
+        message: 'Nice job! Youve made it!'
       }
     },
     methods: {
@@ -33,8 +29,6 @@
     <div class="content">
       <h1><img :src="image" />{{title}}</h1>
       <div v-on:click="updateMessage(message)">{{message}}</div>
-      <div>Environment: {{environment}}</div>
-      <div>Port: {{port}}</div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
I just tried bootstrapping a new project *without* an env.js file, and it didn't load because `ENVIRONMENT` and `PORT` didn't exist. :-(

I really like the idea of demonstrating env.js variables in the default project template -- maybe we could take it out for now and put it back in once we've got a way to vary the `src` template depending on what other features you've selected?